### PR TITLE
Fix missing wrapper for Dialog

### DIFF
--- a/dialog_wrapper.go
+++ b/dialog_wrapper.go
@@ -1,0 +1,31 @@
+package playwright
+
+import (
+	"log"
+
+	"github.com/playwright-community/playwright-go"
+)
+
+type dialogWrapper struct {
+	Dialog playwright.Dialog
+}
+
+func newDialogWrapper(dialog playwright.Dialog) *dialogWrapper {
+	return &dialogWrapper{
+		Dialog: dialog,
+	}
+}
+
+func (dw *dialogWrapper) Accept(texts ...string) {
+	err := dw.Dialog.Accept(texts...)
+	if err != nil {
+		log.Fatalf("could not accept dialog: %v", err)
+	}
+}
+
+func (dw *dialogWrapper) Dismiss() {
+	err := dw.Dialog.Dismiss()
+	if err != nil {
+		log.Fatalf("could not dismiss dialog: %v", err)
+	}
+}

--- a/page_wrapper.go
+++ b/page_wrapper.go
@@ -241,18 +241,18 @@ func (p *pageWrapper) Url() string {
 }
 
 func (p *pageWrapper) Pause() {
-	err := p.Page.Pause();
+	err := p.Page.Pause()
 	if err != nil {
 		log.Fatalf("error while page pause: %v", err)
 	}
 }
 
 func (p *pageWrapper) SetDefaultNavigationTimeout(timeout float64) {
-	p.Page.SetDefaultNavigationTimeout(timeout);
+	p.Page.SetDefaultNavigationTimeout(timeout)
 }
 
 func (p *pageWrapper) SetDefaultTimeout(timeout float64) {
-	p.Page.SetDefaultTimeout(timeout);
+	p.Page.SetDefaultTimeout(timeout)
 }
 
 func (p *pageWrapper) ExpectedDialog(cb func() error) *dialogWrapper {


### PR DESCRIPTION
Before:

Error during building due to missing `dialogWrapper` here:
```
func (p *pageWrapper) ExpectedDialog(cb func() error) *dialogWrapper {
	result, err := p.Page.ExpectedDialog(cb)

	if err != nil {
		log.Fatalf("error with expecting dialog: %v", err)
	}
	return newDialogWrapper(result)
}
```

After:
Build succeed with replaced, minimal wrapper

