### PR TITLE
fix: switch to panic (exception) over fatal (interrupt)

### DIFF
--- a/browser_wrapper.go
+++ b/browser_wrapper.go
@@ -4,21 +4,24 @@ import (
 	"log"
 
 	"github.com/playwright-community/playwright-go"
+	"go.k6.io/k6/js/modules"
 )
 
 type browserWrapper struct {
 	Browser playwright.Browser
+	vu      modules.VU
 }
 
-func newBrowserWrapper(browser playwright.Browser) *browserWrapper {
+func newBrowserWrapper(browser playwright.Browser, vu modules.VU) *browserWrapper {
 	return &browserWrapper{
 		Browser: browser,
+		vu:      vu,
 	}
 }
 
 func (b *browserWrapper) Close() {
 	if err := b.Browser.Close(); err != nil {
-		log.Fatalf("could not close browser: %v", err)
+		Throw(b.vu.Runtime(), "Error closing browser", err)
 	}
 }
 
@@ -26,25 +29,25 @@ func (b *browserWrapper) NewPage() *pageWrapper {
 	page, err := b.Browser.NewPage()
 
 	if err != nil {
-		log.Fatalf("could not create new page: %v", err)
+		Throw(b.vu.Runtime(), "Error creating new page", err)
 	}
 
-	return newPageWrapper(page)
+	return newPageWrapper(page, b.vu)
 }
 
 // Cookies wrapper around playwright cookies fetch function
 func (b *browserWrapper) Cookies() []*playwright.BrowserContextCookiesResult {
 	if b.Browser == nil {
-		log.Fatalf("looks like there's no browser attached. please call `launch()` before accessing the cookies.")
+		log.Panicf("It looks like there's no browser attached. please call `launch()` before accessing the cookies.")
 	}
 
 	if len(b.Browser.Contexts()) == 0 {
-		log.Fatalf("looks like there's no browser contexts are attached. please use `goto()` before accessing the cookies.")
+		log.Panicf("It looks like there's no browser contexts are attached. please use `goto()` before accessing the cookies.")
 	}
 
 	cookies, err := b.Browser.Contexts()[0].Cookies()
 	if err != nil {
-		log.Fatalf("error with getting the cookies from the default context: %v", err)
+		Throw(b.vu.Runtime(), "Error getting cookies from the default context", err)
 	}
 	return cookies
 }

--- a/dialog_wrapper.go
+++ b/dialog_wrapper.go
@@ -1,31 +1,32 @@
 package playwright
 
 import (
-	"log"
-
 	"github.com/playwright-community/playwright-go"
+	"go.k6.io/k6/js/modules"
 )
 
 type dialogWrapper struct {
 	Dialog playwright.Dialog
+	vu     modules.VU
 }
 
-func newDialogWrapper(dialog playwright.Dialog) *dialogWrapper {
+func newDialogWrapper(dialog playwright.Dialog, vu modules.VU) *dialogWrapper {
 	return &dialogWrapper{
 		Dialog: dialog,
+		vu:     vu,
 	}
 }
 
 func (dw *dialogWrapper) Accept(texts ...string) {
 	err := dw.Dialog.Accept(texts...)
 	if err != nil {
-		log.Fatalf("could not accept dialog: %v", err)
+		Throw(dw.vu.Runtime(), "Error accepting dialog", err)
 	}
 }
 
 func (dw *dialogWrapper) Dismiss() {
 	err := dw.Dialog.Dismiss()
 	if err != nil {
-		log.Fatalf("could not dismiss dialog: %v", err)
+		Throw(dw.vu.Runtime(), "Error dismissing dialog", err)
 	}
 }

--- a/locator_wrapper.go
+++ b/locator_wrapper.go
@@ -1,32 +1,33 @@
 package playwright
 
 import (
-	"log"
-
 	"github.com/playwright-community/playwright-go"
+	"go.k6.io/k6/js/modules"
 )
 
 type locatorWrapper struct {
 	Locator playwright.Locator
+	vu      modules.VU
 }
 
-func newLocatorWrapper(locator playwright.Locator) *locatorWrapper {
+func newLocatorWrapper(locator playwright.Locator, vu modules.VU) *locatorWrapper {
 	return &locatorWrapper{
 		Locator: locator,
+		vu:      vu,
 	}
 }
 
 func (loc *locatorWrapper) Click(options ...playwright.PageClickOptions) {
 	err := loc.Locator.Click(options...)
 	if err != nil {
-		log.Fatalf("could not get click work: %v", err)
+		Throw(loc.vu.Runtime(), "Error clicking element", err)
 	}
 }
 
 func (loc *locatorWrapper) Count() int {
 	num, err := loc.Locator.Count()
 	if err != nil {
-		log.Fatalf("Locator count function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error counting elements", err)
 	}
 	return num
 }
@@ -34,23 +35,23 @@ func (loc *locatorWrapper) Count() int {
 func (loc *locatorWrapper) Fill(value string, options ...playwright.FrameFillOptions) {
 	err := loc.Locator.Fill(value, options...)
 	if err != nil {
-		log.Fatalf("fill function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error filling input", err)
 	}
 }
 
 func (loc *locatorWrapper) First() *locatorWrapper {
 	firstLocator, err := loc.Locator.First()
 	if err != nil {
-		log.Fatalf("locator.first function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error getting first element", err)
 	}
 
-	return newLocatorWrapper(firstLocator)
+	return newLocatorWrapper(firstLocator, loc.vu)
 }
 
 func (loc *locatorWrapper) IsDisabled(options ...playwright.FrameIsDisabledOptions) bool {
 	isDisabled, err := loc.Locator.IsDisabled(options...)
 	if err != nil {
-		log.Fatalf("isDisabled function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error checking if element is disabled", err)
 	}
 	return isDisabled
 }
@@ -58,7 +59,7 @@ func (loc *locatorWrapper) IsDisabled(options ...playwright.FrameIsDisabledOptio
 func (loc *locatorWrapper) IsVisible(options ...playwright.FrameIsVisibleOptions) bool {
 	isVisible, err := loc.Locator.IsVisible(options...)
 	if err != nil {
-		log.Fatalf("isVisible function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error checking if element is visible", err)
 	}
 	return isVisible
 }
@@ -66,7 +67,7 @@ func (loc *locatorWrapper) IsVisible(options ...playwright.FrameIsVisibleOptions
 func (loc *locatorWrapper) IsChecked(options ...playwright.FrameIsCheckedOptions) bool {
 	isChecked, err := loc.Locator.IsChecked(options...)
 	if err != nil {
-		log.Fatalf("isChecked function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error checking if element is checked", err)
 	}
 	return isChecked
 }
@@ -74,7 +75,7 @@ func (loc *locatorWrapper) IsChecked(options ...playwright.FrameIsCheckedOptions
 func (loc *locatorWrapper) IsEnabled(options ...playwright.FrameIsEnabledOptions) bool {
 	isEnabled, err := loc.Locator.IsEnabled(options...)
 	if err != nil {
-		log.Fatalf("isEnabled function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error checking if element is enabled", err)
 	}
 	return isEnabled
 }
@@ -82,29 +83,29 @@ func (loc *locatorWrapper) IsEnabled(options ...playwright.FrameIsEnabledOptions
 func (loc *locatorWrapper) Last() *locatorWrapper {
 	lastLocator, err := loc.Locator.Last()
 	if err != nil {
-		log.Fatalf("locator.last function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error getting last element", err)
 	}
-	return newLocatorWrapper(lastLocator)
+	return newLocatorWrapper(lastLocator, loc.vu)
 }
 
 func (loc *locatorWrapper) Type(text string, options ...playwright.PageTypeOptions) {
 	err := loc.Locator.Type(text, options...)
 	if err != nil {
-		log.Fatalf("type function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error getting element type", err)
 	}
 }
 
 func (loc *locatorWrapper) Nth(index int) *locatorWrapper {
-	nthLocator, err := loc.Locator.Nth(index);
+	nthLocator, err := loc.Locator.Nth(index)
 	if err != nil {
-		log.Fatalf("locator.nth function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error getting the nth element", err)
 	}
-	return newLocatorWrapper(nthLocator)
+	return newLocatorWrapper(nthLocator, loc.vu)
 }
 
 func (loc *locatorWrapper) Check() {
-	err := loc.Locator.Check();
+	err := loc.Locator.Check()
 	if err != nil {
-		log.Fatalf("locator.Check function error: %v", err)
+		Throw(loc.vu.Runtime(), "Error checking input field", err)
 	}
 }

--- a/playwright.go
+++ b/playwright.go
@@ -1,8 +1,6 @@
 package playwright
 
 import (
-	"log"
-
 	"github.com/playwright-community/playwright-go"
 	"go.k6.io/k6/js/modules"
 )
@@ -10,35 +8,76 @@ import (
 // Register the extension on module initialization, available to
 // import from JS as "k6/x/playwright".
 func init() {
+	modules.Register("k6/x/playwright", New())
+}
+
+type (
+	// RootModule is the global module instance that will create module
+	// instances for each VU.
+	RootModule struct{}
+
+	// ModuleInstance represents an instance of the JS module.
+	ModuleInstance struct {
+		// vu provides methods for accessing internal k6 objects for a VU
+		vu modules.VU
+		// playwright is the exported type
+		playwright *Playwright
+	}
+)
+
+// Ensure the interfaces are implemented correctly.
+var (
+	_ modules.Instance = &ModuleInstance{}
+	_ modules.Module   = &RootModule{}
+)
+
+// New returns a pointer to a new RootModule instance.
+func New() *RootModule {
+	return &RootModule{}
+}
+
+// NewModuleInstance implements the modules.Module interface returning a new instance for each VU.
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	var p = new(Playwright)
 	pw, err := playwright.Run()
 
 	if err != nil {
-		log.Fatalf("could not start playwright: %v", err)
+		Throw(p.vu.Runtime(), "Unable to start playwright", err)
 	}
 
 	p.Self = pw
 
-	modules.Register("k6/x/playwright", p)
+	return &ModuleInstance{
+		vu:         vu,
+		playwright: &Playwright{Self: pw, vu: vu},
+	}
 }
 
 // Playwright is the k6 extension for a playwright-go client.
 type Playwright struct {
 	Self *playwright.Playwright
+	vu   modules.VU // provides methods for accessing internal k6 objects
 }
 
 // Launch starts the playwright client and launches a browser
 func (p *Playwright) Launch(args playwright.BrowserTypeLaunchOptions) *browserWrapper {
 	browser, err := p.Self.Chromium.Launch(args)
 	if err != nil {
-		log.Fatalf("could not launch browser: %v", err)
+		Throw(p.vu.Runtime(), "Error launching browser", err)
 	}
-	return newBrowserWrapper(browser)
+	return newBrowserWrapper(browser, p.vu)
 }
 
 // Kill closes browser instance and stops puppeteer client
 func (p *Playwright) Kill() {
 	if err := p.Self.Stop(); err != nil {
-		log.Fatalf("could not stop Playwright: %v", err)
+		Throw(p.vu.Runtime(), "Error stopping Playwright", err)
+	}
+}
+
+// Exports implements the modules.Instance interface and returns the exported types for the JS module.
+func (mi *ModuleInstance) Exports() modules.Exports {
+	return modules.Exports{
+		Default: mi.playwright,
 	}
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,11 @@
+package playwright
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+func Throw(rt *goja.Runtime, message string, err error) {
+	panic(rt.ToValue(fmt.Sprintf("%s: %v", message, err)))
+}


### PR DESCRIPTION
Use panic to allow scenarios to handle exceptions and prevent other
K6 iterations for the same VU from being impacted.

To properly be considered an exception by goja, we need to include
a `Value`. The Runtime contains a ToValue that we can use to convert
go strings to a Value accessible in JS.

The runtime is only accessible on the module instance's VU. This
requires some refactoring to the module init and wrapper structs.

https://k6.io/docs/extensions/get-started/create/javascript-extensions/